### PR TITLE
Removed if/unless, added when

### DIFF
--- a/example.fn
+++ b/example.fn
@@ -17,12 +17,18 @@ diff = (x, y) {
 }
 
 say = (enter) {
-  if enter { "Hello" } else { "Goodbye" }
+  when {
+    enter { "Hello" }
+    else { "Goodbye" }
+  }
 }
 say(true)
 say(false)
 
-bool = unless true { 0 } else { 1 }
+bool = when {
+  true { 0 }
+  else { 1 }
+}
 
 cube = (x) { z = x*x*x; z }
 

--- a/example.fn
+++ b/example.fn
@@ -19,7 +19,7 @@ diff = (x, y) {
 say = (enter) {
   when {
     enter { "Hello" }
-    else { "Goodbye" }
+    true { "Goodbye" }
   }
 }
 say(true)
@@ -27,7 +27,6 @@ say(false)
 
 bool = when {
   true { 0 }
-  else { 1 }
 }
 
 cube = (x) { z = x*x*x; z }

--- a/language.txt
+++ b/language.txt
@@ -14,7 +14,8 @@ value => functionPrototype
 value => block
 value => conditional
 
-conditional => :if value block (:else block)?
+conditional => :when :block_open conditionalBranch+ :block_close
+conditionalBranch => value block
 
 block => :block_open primary+ :block_close
 

--- a/runtime.rb
+++ b/runtime.rb
@@ -7,6 +7,11 @@ class Block
   GLOBALS = {
     'true' => true,
     'false' => false,
+
+    # So this is a fun hack.
+    # We set else to true so it will always run in conditionals.
+    'else' => true,
+
     '+' => lambda { |a,b| a + b },
     '*' => lambda { |a,b| a * b },
     '/' => lambda { |a,b| a / b },
@@ -173,11 +178,11 @@ class Block
   end
 
   def evaluate_condition(expr)
-    result = evaluate(expr.condition)
-    if result && expr.true_body
-      evaluate_return_last(expr.true_body.body)
-    elsif (!result) && expr.false_body
-      evaluate_return_last(expr.false_body.body)
+    expr.branches.each do |branch|
+      result = evaluate(branch.condition)
+      if result
+        return evaluate_return_last(branch.body.body)
+      end
     end
   end
 

--- a/runtime.rb
+++ b/runtime.rb
@@ -8,10 +8,6 @@ class Block
     'true' => true,
     'false' => false,
 
-    # So this is a fun hack.
-    # We set else to true so it will always run in conditionals.
-    'else' => true,
-
     '+' => lambda { |a,b| a + b },
     '*' => lambda { |a,b| a * b },
     '/' => lambda { |a,b| a / b },

--- a/tokeniser.rb
+++ b/tokeniser.rb
@@ -10,9 +10,7 @@ GRAMMAR = {
   # Reserved words/symbols
   :use => /\Ause/,
   :import => /\Aimport/,
-  :if => /\Aif/,
-  :unless => /\Aunless/,
-  :else => /\Aelse/,
+  :when => /\Awhen/,
 
   # Infix operators
   :infix_operator => /\A(\+|\-|\*|\/|\.|\=|\|\>)/,


### PR DESCRIPTION
The `when` expression is added instead of `if/unless`.

I think that `case` is a more general form of `if/unless` and I was looking to unify the two; `when` resulted.

`when` is a collection of conditions and blocks that should be run if the condition is true.

I'm undecided which is better:
- Only the block for the first true expression is evaluated (current).
- All true expressions have their block evaluated. (What would the return value be?)
